### PR TITLE
Increase dlmalloc threshold along with granularity

### DIFF
--- a/src/malloc.c
+++ b/src/malloc.c
@@ -44,7 +44,7 @@ struct mmap_record {
 struct mmap_record *records_by_fd = NULL;
 struct mmap_record *records_by_pointer = NULL;
 
-const double GRANULARITY_MULTIPLIER = 2;
+const int GRANULARITY_MULTIPLIER = 2;
 
 /* Create a buffer. This is creating a temporary file and then
  * immediately unlinking it so we do not leave traces in the system. */
@@ -84,7 +84,7 @@ void *fake_mmap(size_t size) {
   }
 
   /* Update dlmalloc's allocation granularity for future calls */
-  dlmalloc_granularity = (size_t) dlmalloc_granularity * GRANULARITY_MULTIPLIER;
+  dlmalloc_granularity *= GRANULARITY_MULTIPLIER;
   dlmallopt(M_GRANULARITY, dlmalloc_granularity);
 
   struct mmap_record *record = malloc(sizeof(struct mmap_record));

--- a/src/malloc.c
+++ b/src/malloc.c
@@ -12,13 +12,15 @@
 void *fake_mmap(size_t);
 int fake_munmap(void *, size_t);
 
+size_t dlmalloc_granularity = ((size_t) 128U * 1024U);
+
 #define MMAP(s) fake_mmap(s)
 #define MUNMAP(a, s) fake_munmap(a, s)
 #define DIRECT_MMAP(s) fake_mmap(s)
 #define DIRECT_MUNMAP(a, s) fake_munmap(a, s)
 #define USE_DL_PREFIX
 #define HAVE_MORECORE 0
-#define DEFAULT_GRANULARITY ((size_t) 1U << 25)
+#define DEFAULT_GRANULARITY (dlmalloc_granularity)
 
 #include "thirdparty/dlmalloc.c"
 
@@ -41,6 +43,8 @@ struct mmap_record {
 /* TODO(rshin): Don't have two hash tables. */
 struct mmap_record *records_by_fd = NULL;
 struct mmap_record *records_by_pointer = NULL;
+
+const double GRANULARITY_MULTIPLIER = 2;
 
 /* Create a buffer. This is creating a temporary file and then
  * immediately unlinking it so we do not leave traces in the system. */
@@ -78,6 +82,10 @@ void *fake_mmap(size_t size) {
   if (pointer == MAP_FAILED) {
     return pointer;
   }
+
+  /* Update dlmalloc's allocation granularity for future calls */
+  dlmalloc_granularity = (size_t) dlmalloc_granularity * GRANULARITY_MULTIPLIER;
+  dlmallopt(M_GRANULARITY, dlmalloc_granularity);
 
   struct mmap_record *record = malloc(sizeof(struct mmap_record));
   record->fd = fd;

--- a/src/malloc.c
+++ b/src/malloc.c
@@ -12,15 +12,14 @@
 void *fake_mmap(size_t);
 int fake_munmap(void *, size_t);
 
-size_t dlmalloc_granularity = ((size_t) 128U * 1024U);
-
 #define MMAP(s) fake_mmap(s)
 #define MUNMAP(a, s) fake_munmap(a, s)
 #define DIRECT_MMAP(s) fake_mmap(s)
 #define DIRECT_MUNMAP(a, s) fake_munmap(a, s)
 #define USE_DL_PREFIX
 #define HAVE_MORECORE 0
-#define DEFAULT_GRANULARITY (dlmalloc_granularity)
+#define DEFAULT_MMAP_THRESHOLD MAX_SIZE_T
+#define DEFAULT_GRANULARITY ((size_t) 128U * 1024U)
 
 #include "thirdparty/dlmalloc.c"
 
@@ -83,11 +82,9 @@ void *fake_mmap(size_t size) {
     return pointer;
   }
 
-  /* Update dlmalloc's allocation granularity for future calls */
-  dlmalloc_granularity *= GRANULARITY_MULTIPLIER;
-  dlmallopt(M_GRANULARITY, dlmalloc_granularity);
-  dlmallopt(M_MMAP_THRESHOLD, dlmalloc_granularity);
-
+  /* Increase dlmalloc's allocation granularity directly. */
+  mparams.granularity *= GRANULARITY_MULTIPLIER;
+  
   struct mmap_record *record = malloc(sizeof(struct mmap_record));
   record->fd = fd;
   record->pointer = pointer;

--- a/src/malloc.c
+++ b/src/malloc.c
@@ -86,6 +86,7 @@ void *fake_mmap(size_t size) {
   /* Update dlmalloc's allocation granularity for future calls */
   dlmalloc_granularity *= GRANULARITY_MULTIPLIER;
   dlmallopt(M_GRANULARITY, dlmalloc_granularity);
+  dlmallopt(M_MMAP_THRESHOLD, dlmalloc_granularity);
 
   struct mmap_record *record = malloc(sizeof(struct mmap_record));
   record->fd = fd;

--- a/src/malloc.c
+++ b/src/malloc.c
@@ -84,7 +84,7 @@ void *fake_mmap(size_t size) {
 
   /* Increase dlmalloc's allocation granularity directly. */
   mparams.granularity *= GRANULARITY_MULTIPLIER;
-  
+
   struct mmap_record *record = malloc(sizeof(struct mmap_record));
   record->fd = fd;
   record->pointer = pointer;


### PR DESCRIPTION
* Double the allocation threshold with each mmap call
 
* Eventually resolve issue of objects being allocated their own file if larger than dlmalloc threshold