### PR TITLE
[WIP] Basic LRU eviction in plasma store.

### DIFF
--- a/lib/python/plasma.py
+++ b/lib/python/plasma.py
@@ -88,7 +88,7 @@ class PlasmaClient(object):
     self.client.plasma_contains.restype = None
     self.client.plasma_seal.restype = None
     self.client.plasma_delete.restype = None
-    self.client.plasma_evict.restype = ctypes.c_int
+    self.client.plasma_evict.restype = ctypes.c_int64
     self.client.plasma_subscribe.restype = ctypes.c_int
 
     self.buffer_from_memory = ctypes.pythonapi.PyBuffer_FromMemory

--- a/lib/python/plasma.py
+++ b/lib/python/plasma.py
@@ -88,6 +88,7 @@ class PlasmaClient(object):
     self.client.plasma_contains.restype = None
     self.client.plasma_seal.restype = None
     self.client.plasma_delete.restype = None
+    self.client.plasma_evict.restype = ctypes.c_int
     self.client.plasma_subscribe.restype = ctypes.c_int
 
     self.buffer_from_memory = ctypes.pythonapi.PyBuffer_FromMemory
@@ -192,6 +193,17 @@ class PlasmaClient(object):
       object_id (str): A string used to identify an object.
     """
     self.client.plasma_delete(self.plasma_conn, make_plasma_id(object_id))
+
+  def evict(self, num_bytes):
+    """Evict some objects until to recover some bytes.
+
+    Recover at least num_bytes bytes if possible.
+
+    Args:
+      num_bytes (int): The number of bytes to attempt to recover.
+    """
+    num_bytes_evicted = self.client.plasma_evict(self.plasma_conn, num_bytes)
+    return num_bytes_evicted
 
   def transfer(self, addr, port, object_id):
     """Transfer local object with id object_id to another plasma instance

--- a/src/plasma.h
+++ b/src/plasma.h
@@ -54,6 +54,8 @@ enum plasma_message_type {
   PLASMA_SEAL,
   /** Delete an object. */
   PLASMA_DELETE,
+  /** Evict objects from the store. */
+  PLASMA_EVICT,
   /** Subscribe to notifications about sealed objects. */
   PLASMA_SUBSCRIBE,
   /** Request transfer to another store. */
@@ -75,6 +77,8 @@ typedef struct {
   /** In a transfer request, this is the port of the Plasma Manager to transfer
    *  the object to. */
   int port;
+  /** A number of bytes. This is used for eviction requests. */
+  int num_bytes;
   /** The number of object IDs that will be included in this request. */
   int num_object_ids;
   /** The IDs of the objects that the request is about. */
@@ -91,6 +95,8 @@ typedef struct {
    *  present and 0 otherwise. Used for plasma_contains and
    *  plasma_fetch. */
   int has_object;
+  /** A number of bytes. This is used for replies to eviction requests. */
+  int num_bytes;
 } plasma_reply;
 
 #endif

--- a/src/plasma.h
+++ b/src/plasma.h
@@ -78,7 +78,7 @@ typedef struct {
    *  the object to. */
   int port;
   /** A number of bytes. This is used for eviction requests. */
-  int num_bytes;
+  int64_t num_bytes;
   /** The number of object IDs that will be included in this request. */
   int num_object_ids;
   /** The IDs of the objects that the request is about. */
@@ -96,7 +96,7 @@ typedef struct {
    *  plasma_fetch. */
   int has_object;
   /** A number of bytes. This is used for replies to eviction requests. */
-  int num_bytes;
+  int64_t num_bytes;
 } plasma_reply;
 
 #endif

--- a/src/plasma_client.c
+++ b/src/plasma_client.c
@@ -282,6 +282,18 @@ void plasma_delete(plasma_connection *conn, object_id object_id) {
   plasma_send_request(conn->store_conn, PLASMA_DELETE, &req);
 }
 
+int plasma_evict(plasma_connection *conn, int num_bytes) {
+  /* Send a request to the store to evict objects. */
+  plasma_request req = {.num_bytes = num_bytes};
+  plasma_send_request(conn->store_conn, PLASMA_EVICT, &req);
+  /* Wait for a response with the number of bytes actually evicted. */
+  plasma_reply reply;
+  int r = read(conn->store_conn, &reply, sizeof(plasma_reply));
+  CHECKM(r != -1, "read error");
+  CHECKM(r != 0, "connection disconnected");
+  return reply.num_bytes;
+}
+
 int plasma_subscribe(plasma_connection *conn) {
   int fd[2];
   /* Create a non-blocking socket pair. This will only be used to send

--- a/src/plasma_client.c
+++ b/src/plasma_client.c
@@ -282,7 +282,7 @@ void plasma_delete(plasma_connection *conn, object_id object_id) {
   plasma_send_request(conn->store_conn, PLASMA_DELETE, &req);
 }
 
-int plasma_evict(plasma_connection *conn, int num_bytes) {
+int64_t plasma_evict(plasma_connection *conn, int64_t num_bytes) {
   /* Send a request to the store to evict objects. */
   plasma_request req = {.num_bytes = num_bytes};
   plasma_send_request(conn->store_conn, PLASMA_EVICT, &req);

--- a/src/plasma_client.h
+++ b/src/plasma_client.h
@@ -173,7 +173,7 @@ void plasma_delete(plasma_connection *conn, object_id object_id);
  * @param num_bytes The number of bytes to try to free up.
  * @return The total number of bytes of space retrieved.
  */
-int plasma_evict(plasma_connection *conn, int num_bytes);
+int64_t plasma_evict(plasma_connection *conn, int64_t num_bytes);
 
 /**
  * Fetch objects from remote plasma stores that have the

--- a/src/plasma_client.h
+++ b/src/plasma_client.h
@@ -166,6 +166,16 @@ void plasma_seal(plasma_connection *conn, object_id object_id);
 void plasma_delete(plasma_connection *conn, object_id object_id);
 
 /**
+ * Delete objects until we have freed up num_bytes bytes or there are no more
+ * released objects that can be deleted.
+ *
+ * @param conn The object containing the connection state.
+ * @param num_bytes The number of bytes to try to free up.
+ * @return The total number of bytes of space retrieved.
+ */
+int plasma_evict(plasma_connection *conn, int num_bytes);
+
+/**
  * Fetch objects from remote plasma stores that have the
  * objects stored.
  *

--- a/src/plasma_store.c
+++ b/src/plasma_store.c
@@ -114,6 +114,14 @@ struct plasma_store_state {
    *  the socket send buffers were full. This is a hash table from client file
    *  descriptor to an array of object_ids to send to that client. */
   notification_queue *pending_notifications;
+  /** The amount of memory (in bytes) that we allow to be allocated in this
+   *  store. */
+  int64_t memory_capacity;
+  /** The amount of memory (in bytes) currently being used. */
+  int64_t memory_used;
+  /** An array of the released objects that in order from least recently
+   *  released to most recently released. */
+  UT_array *released_objects;
 };
 
 plasma_store_state *init_plasma_store(event_loop *loop) {
@@ -123,6 +131,10 @@ plasma_store_state *init_plasma_store(event_loop *loop) {
   state->sealed_objects = NULL;
   state->objects_notify = NULL;
   state->pending_notifications = NULL;
+  /* Find the amount of available memory on the machine. */
+  state->memory_capacity = 1000000000;
+  state->memory_used = 0;
+  utarray_new(state->released_objects, &object_table_entry_icd);
   return state;
 }
 
@@ -137,6 +149,24 @@ void add_client_to_object_clients(object_table_entry *entry,
       return;
     }
   }
+  /* If the object was previously unused, remove the object from the list of
+   * released objects. */
+  /* TODO(rkn): This is slow. It doubles the duration of the tests (33 to 68
+   * seconds). It can be made efficient. */
+  if (utarray_len(entry->clients) == 0) {
+    plasma_store_state *plasma_state = client_info->plasma_state;
+    for (int i = 0; i < utarray_len(plasma_state->released_objects); ++i) {
+      object_id *obj_id =
+          (object_id *) utarray_eltptr(plasma_state->released_objects, i);
+      if (memcmp(obj_id, &entry->object_id, sizeof(object_id)) == 0) {
+        utarray_erase(plasma_state->released_objects, i, 1);
+        break;
+      }
+    }
+    /* TODO(rkn): It'd be nice to check that something was actually removed, but
+     * the first time we call add_client_to_object_clients, it won't be in the
+     * list. */
+  }
   /* Add the client pointer to the list of clients using this object. */
   utarray_push_back(entry->clients, &client_info);
 }
@@ -149,6 +179,17 @@ void create_object(client *client_context,
                    plasma_object *result) {
   LOG_DEBUG("creating object"); /* TODO(pcm): add object_id here */
   plasma_store_state *plasma_state = client_context->plasma_state;
+
+  /* Check if there is enough space to create the object. */
+  int64_t required_space = plasma_state->memory_used + data_size + metadata_size
+                               - plasma_state->memory_capacity;
+  if (required_space > 0) {
+    /* Try to free up one hundred times as much free space as we need right now.
+     */
+    int64_t num_bytes_evicted =
+        evict_objects(client_context, 100 * required_space);
+    CHECK(num_bytes_evicted >= required_space);
+  }
 
   object_table_entry *entry;
   /* TODO(swang): Return these error to the client instead of exiting. */
@@ -234,6 +275,12 @@ int remove_client_from_object_clients(object_table_entry *entry,
     if (*c == client_info) {
       /* Remove the client from the array. */
       utarray_erase(entry->clients, i, 1);
+      /* If no more clients are using this object, add the object to the list of
+       * released objects. */
+      if (utarray_len(entry->clients) == 0) {
+        plasma_store_state *plasma_state = client_info->plasma_state;
+        utarray_push_back(plasma_state->released_objects, &entry->object_id);
+      }
       /* Return 1 to indicate that the client was removed. */
       return 1;
     }
@@ -340,6 +387,33 @@ void delete_object(client *client_context, object_id object_id) {
   free(entry);
 }
 
+/* Remove the least recently released objects. */
+int evict_objects(client *client_context, int num_bytes) {
+  int num_objects_evicted = 0;
+  int num_bytes_evicted = 0;
+  plasma_store_state *plasma_state = client_context->plasma_state;
+  for (int i = 0; i < utarray_len(plasma_state->released_objects); ++i) {
+    if (num_bytes_evicted >= num_bytes) {
+      break;
+    }
+    object_id *obj_id =
+        (object_id *) utarray_eltptr(plasma_state->released_objects, i);
+    object_table_entry *entry;
+    HASH_FIND(handle, plasma_state->open_objects, obj_id, sizeof(object_id),
+              entry);
+    if (entry == NULL) {
+      HASH_FIND(handle, plasma_state->sealed_objects, obj_id, sizeof(object_id),
+                entry);
+    }
+    num_objects_evicted += 1;
+    num_bytes_evicted += (entry->info.data_size + entry->info.metadata_size);
+    delete_object(client_context, *obj_id);
+  }
+  /* Remove the deleted objects from the released objects. */
+  utarray_erase(plasma_state->released_objects, 0, num_objects_evicted);
+  return num_bytes_evicted;
+}
+
 /* Send more notifications to a subscriber. */
 void send_notifications(event_loop *loop,
                         int client_sock,
@@ -439,6 +513,12 @@ void process_message(event_loop *loop,
   case PLASMA_DELETE:
     delete_object(client_context, req->object_ids[0]);
     break;
+  case PLASMA_EVICT: {
+    int num_bytes_evicted = evict_objects(client_context, req->num_bytes);
+    reply.num_bytes = num_bytes_evicted;
+    plasma_send_reply(client_sock, &reply);
+    break;
+  }
   case PLASMA_SUBSCRIBE:
     subscribe_to_updates(client_context, client_sock);
     break;

--- a/src/plasma_store.h
+++ b/src/plasma_store.h
@@ -78,6 +78,16 @@ int contains_object(client *client_context, object_id object_id);
 void delete_object(client *client_context, object_id object_id);
 
 /**
+ * Delete objects until we have freed up num_bytes bytes or there are no more
+ * released objects that can be deleted.
+ *
+ * @param client_context The context of the client making this request.
+ * @param num_bytes The number of bytes to try to free up.
+ * @return The total number of bytes of space retrieved.
+ */
+int evict_objects(client *client_context, int num_bytes);
+
+/**
  * Send notifications about sealed objects to the subscribers. This is called
  * in seal_object. If the socket's send buffer is full, the notification will be
  * buffered, and this will be called again when the send buffer has room.

--- a/src/plasma_store.h
+++ b/src/plasma_store.h
@@ -85,7 +85,7 @@ void delete_object(client *client_context, object_id object_id);
  * @param num_bytes The number of bytes to try to free up.
  * @return The total number of bytes of space retrieved.
  */
-int evict_objects(client *client_context, int num_bytes);
+int64_t evict_objects(client *client_context, int64_t num_bytes);
 
 /**
  * Send notifications about sealed objects to the subscribers. This is called


### PR DESCRIPTION
This is experimental. This adds two things:
1. The Plasma Store keeps track of the least recently released objects. This list is updated whenever a new object is released or when a previously-released object is used.
2. Plasma Clients can call `plasma_evict(num_bytes)`, which will evict objects from the Plasma Store starting with the least recently released object. This will continue removing objects until `num_bytes` bytes have been reclaimed or until there are no more released objects to remove.
